### PR TITLE
Add explanation of converting between floating  and fixed point

### DIFF
--- a/content/fixed-point-math.md
+++ b/content/fixed-point-math.md
@@ -240,7 +240,7 @@ int setup(void)
 }
 ```
 
-Remember that the operations are floating point operations, so they will be slow. There is an exception. If you use `constexpr` or if the compiler detects that an expression is constant, it will calculate it at compile time automatically. This is very useful for setting initial fixed point values from floating point values.
+Remember that those are floating point operations, so they will be slow. There is an exception: if you use `constexpr` or if the compiler detects that an expression is constant, it will calculate it at compile time automatically. This is very useful for setting initial fixed point values from floating point values.
 
 ```c
 int player_x, player_y;

--- a/content/fixed-point-math.md
+++ b/content/fixed-point-math.md
@@ -209,7 +209,7 @@ If you really must divide, you would multiply the numerator by the fixed-point f
 
 ## Converting between fixed and floating point
 
-Okay, so now you have a way to do mathematical operations efficiently. How do you set the initial values in a convenient way? How do you print the values in a way that is easier to understand than very big integer values?
+Now you have a way to do mathematical operations efficiently. How do you set the initial values in a convenient way? How do you print the values in a way that is easier to understand than very big integer values?
 
 Well, you can convert between fixed and floating point easily:
 


### PR DESCRIPTION
This is useful in many situations, like when generating fixed point
constants, or when printing fixed point values for debugging (or non
debugging) purposes.

Also, fix some qualifiers (`extern` isn't needed, `const` is nice to
use).